### PR TITLE
align timestamps

### DIFF
--- a/librato.go
+++ b/librato.go
@@ -16,7 +16,7 @@ type Measurement struct {
 	Counters []*Counter    `json:"counters"`
 	Gauges   []interface{} `json:"gauges"`
 	Source   string        `json:"source,omitempty"`
-	Time     int           `json:"time"`
+	Time     int64         `json:"time"`
 }
 
 func (m *Measurement) Count() int {

--- a/librato.go
+++ b/librato.go
@@ -16,7 +16,7 @@ type Measurement struct {
 	Counters []*Counter    `json:"counters"`
 	Gauges   []interface{} `json:"gauges"`
 	Source   string        `json:"source,omitempty"`
-	Time     int64         `json:"measure_time, omitempty"`
+	Time     int64         `json:"measure_time"`
 }
 
 func (m *Measurement) Count() int {
@@ -95,11 +95,12 @@ func buildMeasurement() (m *Measurement) {
 		m.Source = *libratoSource
 	}
 
+	t := time.Now().Unix()
 	if *snapTime {
 		// unix timestamp, matching our interval
-		t := time.Now().Unix()
-		m.Time = t - (t % *interval)
+		t = t - (t % *interval)
 	}
+	m.Time = t
 
 	m.Counters = make([]*Counter, len(counters))
 	m.Gauges = make([]interface{}, len(gauges))

--- a/librato.go
+++ b/librato.go
@@ -16,7 +16,7 @@ type Measurement struct {
 	Counters []*Counter    `json:"counters"`
 	Gauges   []interface{} `json:"gauges"`
 	Source   string        `json:"source,omitempty"`
-	Time     int64         `json:"time"`
+	Time     int64         `json:"measure_time, omitempty"`
 }
 
 func (m *Measurement) Count() int {
@@ -95,7 +95,7 @@ func buildMeasurement() (m *Measurement) {
 		m.Source = *libratoSource
 	}
 
-	if *alignTimestamp {
+	if *snapTime {
 		// unix timestamp, matching our interval
 		t := time.Now().Unix()
 		m.Time = t - (t % *interval)

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ var (
 	libratoToken   = flag.String("token", "", "librato api token (LIBRATO_TOKEN)")
 	libratoSource  = flag.String("source", "", "librato api source (LIBRATO_SOURCE)")
 	interval       = flag.Int64("flush", 60, "interval at which data is sent to librato (in seconds)")
-	alignTimestamp = flag.Bool("allign-timestamp", false, "align metrics timestamps with flush intervals")
+	alignTimestamp = flag.Bool("align-timestamp", false, "send fixed timestamps, segemented by interval, to align with other servers")
 	percentiles    = flag.String("percentiles", "", "comma separated list of percentiles to calculate for timers (eg. \"95,99.5\")")
 	proxy          = flag.String("proxy", "", "send metrics to a proxy rather than directly to librato")
 	debug          = flag.Bool("debug", false, "enable logging of inputs and submissions")

--- a/main.go
+++ b/main.go
@@ -12,16 +12,16 @@ import (
 const VERSION = "1.0.0"
 
 var (
-	address        = flag.String("address", "0.0.0.0:8125", "udp listen address")
-	libratoUser    = flag.String("user", "", "librato api username (LIBRATO_USER)")
-	libratoToken   = flag.String("token", "", "librato api token (LIBRATO_TOKEN)")
-	libratoSource  = flag.String("source", "", "librato api source (LIBRATO_SOURCE)")
-	interval       = flag.Int64("flush", 60, "interval at which data is sent to librato (in seconds)")
-	alignTimestamp = flag.Bool("align-timestamp", false, "send fixed timestamps, segemented by interval, to align with other servers")
-	percentiles    = flag.String("percentiles", "", "comma separated list of percentiles to calculate for timers (eg. \"95,99.5\")")
-	proxy          = flag.String("proxy", "", "send metrics to a proxy rather than directly to librato")
-	debug          = flag.Bool("debug", false, "enable logging of inputs and submissions")
-	version        = flag.Bool("version", false, "print version and exit")
+	address       = flag.String("address", "0.0.0.0:8125", "udp listen address")
+	libratoUser   = flag.String("user", "", "librato api username (LIBRATO_USER)")
+	libratoToken  = flag.String("token", "", "librato api token (LIBRATO_TOKEN)")
+	libratoSource = flag.String("source", "", "librato api source (LIBRATO_SOURCE)")
+	interval      = flag.Int64("flush", 60, "interval at which data is sent to librato (in seconds)")
+	snapTime      = flag.Bool("snaptime", false, "snap timestamps to interval, to align with other servers started at different offsets")
+	percentiles   = flag.String("percentiles", "", "comma separated list of percentiles to calculate for timers (eg. \"95,99.5\")")
+	proxy         = flag.String("proxy", "", "send metrics to a proxy rather than directly to librato")
+	debug         = flag.Bool("debug", false, "enable logging of inputs and submissions")
+	version       = flag.Bool("version", false, "print version and exit")
 )
 
 func monitor() {

--- a/main.go
+++ b/main.go
@@ -12,15 +12,16 @@ import (
 const VERSION = "1.0.0"
 
 var (
-	address       = flag.String("address", "0.0.0.0:8125", "udp listen address")
-	libratoUser   = flag.String("user", "", "librato api username (LIBRATO_USER)")
-	libratoToken  = flag.String("token", "", "librato api token (LIBRATO_TOKEN)")
-	libratoSource = flag.String("source", "", "librato api source (LIBRATO_SOURCE)")
-	interval      = flag.Int64("flush", 60, "interval at which data is sent to librato (in seconds)")
-	percentiles   = flag.String("percentiles", "", "comma separated list of percentiles to calculate for timers (eg. \"95,99.5\")")
-	proxy         = flag.String("proxy", "", "send metrics to a proxy rather than directly to librato")
-	debug         = flag.Bool("debug", false, "enable logging of inputs and submissions")
-	version       = flag.Bool("version", false, "print version and exit")
+	address        = flag.String("address", "0.0.0.0:8125", "udp listen address")
+	libratoUser    = flag.String("user", "", "librato api username (LIBRATO_USER)")
+	libratoToken   = flag.String("token", "", "librato api token (LIBRATO_TOKEN)")
+	libratoSource  = flag.String("source", "", "librato api source (LIBRATO_SOURCE)")
+	interval       = flag.Int64("flush", 60, "interval at which data is sent to librato (in seconds)")
+	alignTimestamp = flag.Bool("allign-timestamp", false, "align metrics timestamps with flush intervals")
+	percentiles    = flag.String("percentiles", "", "comma separated list of percentiles to calculate for timers (eg. \"95,99.5\")")
+	proxy          = flag.String("proxy", "", "send metrics to a proxy rather than directly to librato")
+	debug          = flag.Bool("debug", false, "enable logging of inputs and submissions")
+	version        = flag.Bool("version", false, "print version and exit")
 )
 
 func monitor() {


### PR DESCRIPTION
* adds option to align measurement timestamps across multiple servers `snaptime`

naming related to official librato implementation, see

* https://github.com/librato/statsd-librato-backend
* https://github.com/librato/statsd-librato-backend/blob/53d379c19220d0c4692fc416cddc202bc0e6dad7/lib/librato.js#L240
* https://github.com/librato/statsd-librato-backend/blob/53d379c19220d0c4692fc416cddc202bc0e6dad7/lib/librato.js#L165

This version is running on our servers successfully for about four hours now :smile: I tried my best to test that nothing is broken if the feature is disabled. Changes are not that extensive.